### PR TITLE
Fix test file reading on Windows by specifying UTF-8 encoding

### DIFF
--- a/tests/test_scrapers_with_base_url.py
+++ b/tests/test_scrapers_with_base_url.py
@@ -29,7 +29,7 @@ def get_test_files():
 
 def load_html(file_path):
     try:
-        with open(file_path, "r") as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             return BeautifulSoup(file.read(), "html.parser")
     except Exception as e:
         print(f"Error loading HTML file {file_path}: {e}")
@@ -66,14 +66,14 @@ def test_scraper(mocker, scraper_module, base_url_file, html_file, exp_output_fi
     scraper_class = find_class(module, module_name)
 
     # Read base_url from the file
-    with open(base_url_file, newline="") as csvfile:
+    with open(base_url_file, newline="", encoding="utf-8") as csvfile:
         reader = csv.reader(csvfile)
         row = next(reader, None)  # Read the first (and only) row
         if row:
             base_url = row[0]
 
     # Read the HTML content from the file
-    with open(html_file, "r") as file:
+    with open(html_file, "r", encoding="utf-8") as file:
         html_content = file.read()
 
     # Instantiate the scraper using the HTML content
@@ -88,7 +88,7 @@ def test_scraper(mocker, scraper_module, base_url_file, html_file, exp_output_fi
 
     # Load expected results
     expected_links = []
-    with open(exp_output_file, newline="") as csvfile:
+    with open(exp_output_file, newline="", encoding="utf-8") as csvfile:
         reader = csv.reader(csvfile)
         for row in reader:
             expected_links.extend(row)

--- a/tests/test_scrapers_with_html.py
+++ b/tests/test_scrapers_with_html.py
@@ -28,7 +28,7 @@ def get_test_files():
 
 def load_html(file_path):
     try:
-        with open(file_path, "r") as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             return BeautifulSoup(file.read(), "html.parser")
     except Exception as e:
         print(f"Error loading HTML file {file_path}: {e}")
@@ -65,7 +65,7 @@ def test_scraper(mocker, scraper_module, html_file, exp_output_file):
     scraper_class = find_class(module, module_name)
 
     # Read the HTML content from the file
-    with open(html_file, "r") as file:
+    with open(html_file, "r", encoding="utf-8") as file:
         html_content = file.read()
 
     # Instantiate the scraper using the HTML content
@@ -80,7 +80,7 @@ def test_scraper(mocker, scraper_module, html_file, exp_output_file):
 
     # Load expected results
     expected_links = []
-    with open(exp_output_file, newline="") as csvfile:
+    with open(exp_output_file, newline="", encoding="utf-8") as csvfile:
         reader = csv.reader(csvfile)
         for row in reader:
             expected_links.extend(row)


### PR DESCRIPTION
Hi, while running the test suite on Windows, I encountered errors (tests fails) related to file reading due to the platform's default encoding.

This PR make the tests run consistently across platforms by explicitly set encoding="utf-8" when opening HTML and CSV files in the test suite.

This ensures that files are read with a consistent encoding regardless of the operating system, preventing issues with special characters or platform-specific defaults.